### PR TITLE
Update JAVA dependency to 22

### DIFF
--- a/interface/build.gradle.kts
+++ b/interface/build.gradle.kts
@@ -20,8 +20,8 @@ android {
     }
 
     compileOptions {
-        targetCompatibility = JavaVersion.VERSION_21
-        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_22
+        sourceCompatibility = JavaVersion.VERSION_22
     }
 
     publishing {

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -19,8 +19,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_22
+        targetCompatibility = JavaVersion.VERSION_22
     }
 
     publishing {


### PR DESCRIPTION
If the build machine has installed latest version of JDK:

Kotlin version used in the repo uses Java 22. But Java is not set to same version, causing "Inconsistent JVM-target compatibility detected for tasks 'compileJava' (21) and 'compileKotlin' (22)" error.
This updates the JVM target to resolve the issue.